### PR TITLE
[FEAT] 예매 확인 페이지 및 예매 상세 페이지

### DIFF
--- a/client/src/components/Footer/Footer.module.css
+++ b/client/src/components/Footer/Footer.module.css
@@ -1,11 +1,7 @@
 .footerLayout {
-  position: relative;
-  overflow: hidden;
-  bottom: 0;
-  left: 0;
   width: 100%;
-  padding: 3.2rem 1.6rem;
-  background-color: #f1f1f1;
+  padding: 2rem 1.6rem;
+  background-color: #e8e8e8;
   text-align: left;
 }
 
@@ -15,26 +11,48 @@
 
 .footerLinksContainer {
   display: flex;
-  flex-wrap: nowrap;
-  overflow: hidden;
-  align-items: center;
+  flex-wrap: wrap;
   justify-content: space-between;
   width: 100%;
 }
 
 .footerLinksBox {
   display: flex;
-  white-space: nowrap;
+  flex-wrap: wrap;
 }
 
 .footerLinksBox a {
   margin-right: 1.6rem;
+  margin-bottom: 0.8rem;
   color: #999;
   text-decoration: none;
 }
 
 .footerAppsBox {
   display: flex;
+  flex-wrap: wrap;
   gap: 1.6rem;
-  white-space: nowrap;
+  margin-top: 1.6rem;
+}
+
+@media (min-width: 768px) {
+  .footerLinksContainer {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .footerLinksBox {
+    flex-wrap: nowrap;
+    margin-bottom: 0;
+  }
+
+  .footerLinksBox a {
+    margin-bottom: 0;
+  }
+
+  .footerAppsBox {
+    flex-wrap: nowrap;
+    margin-top: 0;
+  }
 }

--- a/client/src/pages/ReservationDetail/ReservationDetail.jsx
+++ b/client/src/pages/ReservationDetail/ReservationDetail.jsx
@@ -1,0 +1,60 @@
+import styles from './ReservationDetail.module.css';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+export default function ReservationDetail() {
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const {
+    imageUrl,
+    title,
+    location,
+    date,
+    status,
+    people,
+    name = '아뜰리',
+    email = 'test@email.com',
+    phone = '010-1234-5678',
+    payment,
+    total,
+  } = state || {};
+  const handleBack = () => navigate(`/mypage`);
+
+  return (
+    <div className={styles.layout}>
+      <h2 className={styles.title}>예매 상세 내역</h2>
+
+      <div className={styles.card}>
+        <img src={imageUrl} alt={title} className={styles.poster} />
+        <div className={styles.info}>
+          <h3>{title}</h3>
+          <p>
+            <strong>장소:</strong> {location}
+          </p>
+          <p>
+            <strong>일시:</strong> {date}
+          </p>
+          <p>
+            <strong>상태:</strong> {status}
+          </p>
+        </div>
+      </div>
+
+      <div className={styles.detailBox}>
+        <h4 className={styles.detailTitle}>예매자 정보</h4>
+        <p>이름: {name}</p>
+        <p>이메일: {email}</p>
+        <p>전화번호: {phone}</p>
+      </div>
+
+      <div className={styles.detailBox}>
+        <h4 className={styles.detailTitle}>예매 상세 정보</h4>
+        <p>인원: {people}</p>
+        <p>결제 수단: {payment}</p>
+        <p>결제 금액: {total}원</p>
+      </div>
+      <button className={styles.button} onClick={handleBack}>
+        닫기
+      </button>
+    </div>
+  );
+}

--- a/client/src/pages/ReservationDetail/ReservationDetail.module.css
+++ b/client/src/pages/ReservationDetail/ReservationDetail.module.css
@@ -56,5 +56,4 @@
   background-color: #3f51b5;
   color: #fff;
   font-size: 1.6rem;
-  transition: background-color 0.2s ease;
 }

--- a/client/src/pages/ReservationDetail/ReservationDetail.module.css
+++ b/client/src/pages/ReservationDetail/ReservationDetail.module.css
@@ -1,0 +1,60 @@
+.layout {
+  padding: 2rem;
+  background-color: #fff;
+}
+
+.title {
+  margin-bottom: 2rem;
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.card {
+  display: flex;
+  gap: 1.2rem;
+  margin-bottom: 2rem;
+  padding-bottom: 1.6rem;
+  border-bottom: 0.1rem solid #ddd;
+}
+
+.poster {
+  width: 12rem;
+  height: 16rem;
+  border-radius: 0.8rem;
+  object-fit: cover;
+}
+
+.info {
+  font-size: 1.4rem;
+  line-height: 1.6;
+}
+
+.detailBox {
+  margin-bottom: 1.6rem;
+  padding: 1.6rem;
+  border: 0.1rem solid #ddd;
+  border-radius: 1rem;
+  background-color: #fafafa;
+  font-size: 1.2rem;
+}
+
+.detailTitle {
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+}
+
+.detailBox p {
+  font-size: 1.4rem;
+}
+
+.button {
+  width: 100%;
+  margin-top: 1rem;
+  padding: 1.2rem;
+  border: none;
+  border-radius: 0.8rem;
+  background-color: #3f51b5;
+  color: #fff;
+  font-size: 1.6rem;
+  transition: background-color 0.2s ease;
+}

--- a/client/src/pages/MyPage/components/Sections/SectionCard/SectionCard.jsx
+++ b/client/src/pages/MyPage/components/Sections/SectionCard/SectionCard.jsx
@@ -5,9 +5,10 @@ import { useNavigate } from 'react-router-dom';
 export default function SectionCard({ item, type }) {
   const { imageUrl, title, location, date, status } = item;
   const navigate = useNavigate();
+  const reservationId = 0;
 
   const handleNavigate = () => {
-    navigate('/reservation/complete');
+    navigate(`/reservation/detail/${reservationId}`, { state: item });
   };
 
   return (

--- a/client/src/pages/Purchase/Purchase.jsx
+++ b/client/src/pages/Purchase/Purchase.jsx
@@ -30,14 +30,7 @@ export default function Purchase() {
 
     const people = { adults, teens, children };
     const reservationData = {
-      exhibition,
-      date,
-      time,
-      people,
-      total,
-      email,
-      phone,
-      name,
+      ...state,
       payment: selectedPayment,
     };
     navigate(`/reservation/complete/${reservationId}`, {

--- a/client/src/pages/Purchase/Purchase.jsx
+++ b/client/src/pages/Purchase/Purchase.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import styles from './Purchase.module.css';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 export default function Purchase() {
-  const navigate = useNavigate();
+  const { reservationId } = useParams();
   const { state } = useLocation();
+  const navigate = useNavigate();
   const [selectedPayment, setSelectedPayment] = useState('');
 
   const {
@@ -19,12 +20,29 @@ export default function Purchase() {
   } = state || {};
 
   const handleBack = () => navigate(`/reservation/${exhibition.id}`);
+
   const handlePayment = () => {
     if (!selectedPayment) {
       alert('결제 수단을 선택해주세요.');
       return;
     }
     alert(`${selectedPayment}로 결제를 진행합니다.`);
+
+    const people = { adults, teens, children };
+    const reservationData = {
+      exhibition,
+      date,
+      time,
+      people,
+      total,
+      email,
+      phone,
+      name,
+      payment: selectedPayment,
+    };
+    navigate(`/reservation/complete/${reservationId}`, {
+      state: reservationData,
+    });
   };
 
   const renderUserInfo = () => (
@@ -80,6 +98,7 @@ export default function Purchase() {
       네이버페이: 'naver',
       '카드 결제': 'basic',
     };
+
     return (
       <div className={styles.paymentMethod}>
         <h3>결제 수단</h3>

--- a/client/src/pages/Purchase/Purchase.module.css
+++ b/client/src/pages/Purchase/Purchase.module.css
@@ -22,7 +22,7 @@ p {
 }
 
 .orderSection {
-  border: 1px solid #ddd;
+  border: 0.1rem solid #ddd;
   border-radius: 1rem;
   padding: 1.6rem;
   margin-bottom: 2rem;
@@ -39,8 +39,8 @@ p {
 }
 
 .productImage {
-  width: 100px;
-  height: 140px;
+  width: 10rem;
+  height: 14rem;
   object-fit: cover;
   border-radius: 0.8rem;
 }
@@ -71,7 +71,7 @@ h3 {
 }
 
 .paymentMethod {
-  border: 1px solid #ddd;
+  border: 0.1rem solid #ddd;
   border-radius: 1rem;
   padding: 1.6rem;
   margin-bottom: 2rem;

--- a/client/src/pages/Purchase/Purchase.module.css
+++ b/client/src/pages/Purchase/Purchase.module.css
@@ -22,10 +22,10 @@ p {
 }
 
 .orderSection {
+  margin-bottom: 2rem;
+  padding: 1.6rem;
   border: 0.1rem solid #ddd;
   border-radius: 1rem;
-  padding: 1.6rem;
-  margin-bottom: 2rem;
 }
 
 .userInfo {
@@ -41,8 +41,8 @@ p {
 .productImage {
   width: 10rem;
   height: 14rem;
-  object-fit: cover;
   border-radius: 0.8rem;
+  object-fit: cover;
 }
 
 .productInfo {
@@ -51,37 +51,38 @@ p {
   font-size: 1.2rem;
   font-weight: 500;
 }
+
 .paymentInfo,
 .discountInfo,
 .paymentMethod {
-  border: 1px solid #ddd;
-  border-radius: 1rem;
-  padding: 1.6rem;
   margin-bottom: 2rem;
+  padding: 1.6rem;
+  border: 0.1rem solid #ddd;
+  border-radius: 1rem;
   font-size: 1.4rem;
 }
+
 h3 {
   margin-bottom: 1rem;
 }
 
 .total {
-  font-weight: bold;
-  color: #3f51b5;
   margin-top: 0.8rem;
+  color: #3f51b5;
+  font-weight: bold;
 }
 
 .paymentMethod {
+  margin-bottom: 2rem;
+  padding: 1.6rem;
   border: 0.1rem solid #ddd;
   border-radius: 1rem;
-  padding: 1.6rem;
-  margin-bottom: 2rem;
 }
 
 .paymentMethod label {
   display: block;
   font-size: 1.4rem;
   line-height: 1.6;
-
   cursor: pointer;
 }
 
@@ -100,15 +101,9 @@ h3 {
   width: 100%;
   margin-bottom: 2rem;
   padding: 1.2rem;
-  font-size: 1.6rem;
-  background-color: #3f51b5;
-  color: #fff;
   border: none;
   border-radius: 0.8rem;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-}
-
-.paymentButton:hover {
-  background-color: #303f9f;
+  background-color: #3f51b5;
+  color: #fff;
+  font-size: 1.6rem;
 }

--- a/client/src/pages/Reservation/Reservation.jsx
+++ b/client/src/pages/Reservation/Reservation.jsx
@@ -11,7 +11,7 @@ const dummyExhibitions = [
     id: '0',
     title: '어둠 속의 대화',
     imageUrl: exhibitionImg,
-    location: '북촌 어둠속의 대화',
+    location: '북촌 아트갤러리',
     dateRange: '2025.03.15 ~ 2025.06.21',
     duration: '100분',
   },
@@ -45,7 +45,7 @@ export default function Reservation() {
       people,
       total,
     };
-    const dummyReservationId = Date.now();
+    const dummyReservationId = Date.now().toString();
     navigate(`/purchase/${dummyReservationId}`, { state: reservationData });
   };
 

--- a/client/src/pages/Reservation/Reservation.module.css
+++ b/client/src/pages/Reservation/Reservation.module.css
@@ -57,11 +57,6 @@
   background-color: #3f51b5;
   color: #fff;
   font-size: 1.6rem;
-  transition: background-color 0.2s ease;
-}
-
-.button:hover {
-  background-color: #303f9f;
 }
 
 .totalSection {

--- a/client/src/pages/Reservation/Reservation.module.css
+++ b/client/src/pages/Reservation/Reservation.module.css
@@ -36,7 +36,7 @@
 
 .exhibitionDetail {
   margin-top: 1rem;
-  font-size: 1.2rem;
+  font-size: 1.4rem;
 }
 
 .formContainer {

--- a/client/src/pages/ReservationComplete/ReservationComplete.jsx
+++ b/client/src/pages/ReservationComplete/ReservationComplete.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import styles from './ReservationComplete.module.css';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+export default function ReservationComplete() {
+  const { state } = useLocation();
+  const navigate = useNavigate();
+
+  const {
+    exhibition = {},
+    date,
+    time,
+    people,
+    total,
+    email,
+    phone,
+    name,
+    payment,
+  } = state || {};
+
+  const handleComplete = () => navigate('/');
+
+  return (
+    <div className={styles.layout}>
+      <h2 className={styles.completeMessage}>
+        ✅ 전시 예매가 정상적으로 완료되었습니다.
+      </h2>
+
+      <section className={styles.card}>
+        <h3 className={styles.sectionTitle}>예매 내용</h3>
+        <div className={styles.ticketInfo}>
+          <img
+            src={exhibition.imageUrl}
+            alt='전시 포스터'
+            className={styles.poster}
+          />
+          <div className={styles.details}>
+            <p>
+              <strong>전시명</strong>: {exhibition.title}
+            </p>
+            <p>
+              <strong>장소</strong>: {exhibition.location}
+            </p>
+            <p>
+              <strong>일시</strong>: {exhibition.dateRange}
+            </p>
+            <p>
+              <strong>예매자</strong>: {name}
+            </p>
+            <p>
+              <strong>이메일</strong>: {email}
+            </p>
+
+            <p>
+              <strong>매수</strong>: 성인 {people.adults}, 청소년 {people.teens}
+              , 유아 {people.children}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.card}>
+        <h3 className={styles.sectionTitle}>결제 정보</h3>
+        <p>
+          <strong>- 결제 금액</strong>: {total.toLocaleString()}
+        </p>
+        <p>
+          <strong>- 할인 금액</strong>: 1,000원
+        </p>
+      </section>
+
+      <section className={styles.card}>
+        <h3 className={styles.sectionTitle}>결제 상세 정보</h3>
+        <p>
+          <strong>결제 방법</strong>: {payment}
+        </p>
+        <p>
+          <strong>결제 금액</strong>: {(total - 1000).toLocaleString()}원
+        </p>
+      </section>
+      <button className={styles.completeButton} onClick={handleComplete}>
+        닫기
+      </button>
+    </div>
+  );
+}

--- a/client/src/pages/ReservationComplete/ReservationComplete.module.css
+++ b/client/src/pages/ReservationComplete/ReservationComplete.module.css
@@ -1,0 +1,60 @@
+.layout {
+  padding: 2rem;
+  background-color: #ffffff;
+  font-family: 'Pretendard', sans-serif;
+}
+
+.completeMessage {
+  text-align: center;
+  font-size: 1.7rem;
+  font-weight: bold;
+  color: #4caf50;
+  margin: 3.5rem 0;
+}
+
+.card {
+  border: 1px solid #ddd;
+  border-radius: 1rem;
+  padding: 1.6rem;
+  margin-bottom: 2rem;
+  font-size: 1.4rem;
+  background-color: #f9f9f9;
+}
+
+.sectionTitle {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+
+.ticketInfo {
+  display: flex;
+  gap: 1.2rem;
+}
+
+.poster {
+  width: 100px;
+  height: 140px;
+  object-fit: cover;
+  border-radius: 0.8rem;
+  border: 1px solid #ccc;
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  font-size: 1.3rem;
+  line-height: 1.6;
+}
+
+.completeButton {
+  width: 100%;
+  margin-bottom: 2rem;
+  padding: 1.2rem;
+  font-size: 1.6rem;
+  background-color: #3f51b5;
+  color: #fff;
+  border: none;
+  border-radius: 0.8rem;
+}

--- a/client/src/pages/ReservationComplete/ReservationComplete.module.css
+++ b/client/src/pages/ReservationComplete/ReservationComplete.module.css
@@ -1,30 +1,29 @@
 .layout {
   padding: 2rem;
   background-color: #ffffff;
-  font-family: 'Pretendard', sans-serif;
 }
 
 .completeMessage {
   text-align: center;
+  margin: 3.5rem 0;
+  color: hsl(122, 39%, 49%);
   font-size: 1.7rem;
   font-weight: bold;
-  color: #4caf50;
-  margin: 3.5rem 0;
 }
 
 .card {
-  border: 1px solid #ddd;
-  border-radius: 1rem;
-  padding: 1.6rem;
   margin-bottom: 2rem;
-  font-size: 1.4rem;
+  padding: 1.6rem;
+  border: 0.1rem solid #ddd;
+  border-radius: 1rem;
   background-color: #f9f9f9;
+  font-size: 1.4rem;
 }
 
 .sectionTitle {
+  margin-bottom: 1rem;
   font-size: 1.5rem;
   font-weight: bold;
-  margin-bottom: 1rem;
 }
 
 .ticketInfo {
@@ -33,11 +32,11 @@
 }
 
 .poster {
-  width: 100px;
-  height: 140px;
-  object-fit: cover;
+  width: 10rem;
+  height: 14rem;
+  border: 0.1rem solid #ccc;
   border-radius: 0.8rem;
-  border: 1px solid #ccc;
+  object-fit: cover;
 }
 
 .details {
@@ -52,9 +51,9 @@
   width: 100%;
   margin-bottom: 2rem;
   padding: 1.2rem;
-  font-size: 1.6rem;
-  background-color: #3f51b5;
-  color: #fff;
   border: none;
   border-radius: 0.8rem;
+  background-color: #3f51b5;
+  color: #fff;
+  font-size: 1.6rem;
 }

--- a/client/src/router/Router.jsx
+++ b/client/src/router/Router.jsx
@@ -20,6 +20,7 @@ import LayoutWithChatbot from '../layouts/LayoutWithChatbot';
 import LayoutWithHeader from '../layouts/LayoutWithHeader';
 import Notice from '../pages/Notice/Notice';
 import NoticeDetail from '../pages/NoticeDetail/NoticeDetail';
+import ReservationComplete from '../pages/ReservationComplete/ReservationComplete';
 
 const router = createBrowserRouter([
   {
@@ -63,6 +64,10 @@ const router = createBrowserRouter([
           { path: '/mypage/edit', element: <EditProfile /> },
           { path: '/reservation/:exhibitionId', element: <Reservation /> },
           { path: '/purchase/:reservationId', element: <Purchase /> },
+          {
+            path: '/reservation/complete/:reservationId',
+            element: <ReservationComplete />,
+          },
         ],
       },
     ],

--- a/client/src/router/Router.jsx
+++ b/client/src/router/Router.jsx
@@ -21,6 +21,7 @@ import LayoutWithHeader from '../layouts/LayoutWithHeader';
 import Notice from '../pages/Notice/Notice';
 import NoticeDetail from '../pages/NoticeDetail/NoticeDetail';
 import ReservationComplete from '../pages/ReservationComplete/ReservationComplete';
+import ReservationDetail from '../pages/\bReservationDetail/ReservationDetail';
 
 const router = createBrowserRouter([
   {
@@ -67,6 +68,10 @@ const router = createBrowserRouter([
           {
             path: '/reservation/complete/:reservationId',
             element: <ReservationComplete />,
+          },
+          {
+            path: '/reservation/detail/:reservationId',
+            element: <ReservationDetail />,
           },
         ],
       },


### PR DESCRIPTION
## #️⃣연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

- close: #30 

## 🪄작업 내용

> 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다.


https://github.com/user-attachments/assets/47747595-4df2-437d-bb16-08e593d344c2

- 푸터 컴포넌트 수정
- 구매 후 예매 성공 페이지 구현
- 이후 마이페이지에서 예매 상세 내역 확인 페이지 구현

## 💖리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 논의가 필요한 부분 등 자유롭게 작성해주세요.

-  { path: '/reservation/:exhibitionId', element: <Reservation /> }, // 예매 페이지
{ path: '/purchase/:reservationId', element: <Purchase /> }, // 결제 페이지
{path: '/reservation/complete/:reservationId', element: <ReservationComplete />}, // 결제 확정 페이지
{path: '/reservation/detail/:reservationId', element: <ReservationDetail />} // 예매 상세 내역 페이지
경로를 위와 같이 설정하였습니다. 결제가 완료되면 생성되는 reservationId로 해당 결제(예매)건에 대해 각 페이지에 접근하도록 해보았습니다. 검토해주시면 감사드리겠습니다.

- UI가 간단한 편이고 jsx return문 내부의 가독성이 떨어지지 않는 편이라 따로 렌더함수로 분리하지 않았습니다.
- 해당 페이지들에서 사용될 데이터 값들은 api 연결 후 재정리 할 예정입니다.

- 푸터가 웹 기준으로 되어있어 모바일 기준 UI로 수정하였습니다.
